### PR TITLE
[WIP] Optimize the MIRK method

### DIFF
--- a/src/BoundaryValueDiffEq.jl
+++ b/src/BoundaryValueDiffEq.jl
@@ -22,12 +22,12 @@ function BVProblem(f,bc,u0,tspan; iip = DiffEqBase.isinplace(f,3))
     BVProblem{typeof(u0),eltype(tspan),iip,typeof(f),typeof(bc)}(f,bc,u0,tspan)
 end
 
-immutable MIRKTableau{T}
+immutable MIRKTableau{T, U<:AbstractArray}
     c::Vector{T}
     v::Vector{T}
     b::Vector{T}
     x::Matrix{T}
-    K::Matrix{T} # Cache
+    K::Vector{U} # Cache
 end
 
 # ODE BVP problem system

--- a/src/collocation.jl
+++ b/src/collocation.jl
@@ -31,12 +31,12 @@ function Φ!{T}(S::BVPSystem{T})
             x_new = x[i] + c[r]*h
             y_new = (one(T)-v[r])*y[i] + v[r]*y[i+1]
             if r > 1
-                y_new += h * sum(j->X[r,j]*@view(K[:, j]), 1:r-1)
+                y_new += h * sum(j->X[r,j]*K[j], 1:r-1)
             end
-            fun!(x_new, y_new, @view(K[:, r]))
+            fun!(x_new, y_new, K[r])
         end
         # Update residual
-        residual[i] = y[i+1] - y[i] - h * sum(j->b[j]*@view(K[:, j]), 1:order)
+        residual[i] = y[i+1] - y[i] - h * sum(j->b[j]*K[j], 1:order)
     end
     eval_bc_residual!(S)
 end

--- a/src/collocation.jl
+++ b/src/collocation.jl
@@ -20,9 +20,8 @@ end
 
 @inline eval_bc_residual!{T}(S::BVPSystem{T}) = S.bc!(S.residual[end], S.y)
 
-function Φ!{T}(S::BVPSystem{T})
+function Φ!{T}(S::BVPSystem{T}, TU::MIRKTableau)
     M, N, residual, x, y, fun!, order = S.M, S.N, S.residual, S.x, S.y, S.fun!, S.order
-    TU = constructMIRK(S)
     c, v, b, X, K = TU.c, TU.v, TU.b, TU.x, TU.K
     for i in 1:N-1
         h = x[i+1] - x[i]

--- a/src/collocation.jl
+++ b/src/collocation.jl
@@ -30,7 +30,11 @@ function Φ!{T}(S::BVPSystem{T}, TU::MIRKTableau)
             x_new = x[i] + c[r]*h
             y_new = (one(T)-v[r])*y[i] + v[r]*y[i+1]
             if r > 1
-                y_new += h * sum(j->X[r,j]*K[j], 1:r-1)
+                inc = zero(T)
+                for j in 1:r-1
+                    inc += X[r, j] * K[j]
+                end
+                y_new += h * inc                
             end
             fun!(x_new, y_new, K[r])
         end

--- a/src/mirk_tableaus.jl
+++ b/src/mirk_tableaus.jl
@@ -6,8 +6,8 @@ function constructMIRK_IV{T}(S::BVPSystem{T})
          0      0       0 0
          1//8   -1//8   0 0
          3//64  -9//64  0 0]
-    K = Matrix{T}(S.M,4)
-    MIRKTableau{T}(T.(c),T.(v),T.(b),T.(x),K)
+    K = vector_alloc(T, S.M, 4)
+    MIRKTableau(T.(c),T.(v),T.(b),T.(x),K)
 end
 
 constructMIRK{T}(S::BVPSystem{T}) = MIRK_dispatcher(S, Val{S.order})

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -23,11 +23,12 @@ function solve(prob::BVProblem, alg::MIRK; dt=0.0, kwargs...)
     x = collect(linspace(prob.tspan..., n+1))
     S = BVPSystem(prob.f, prob.bc, x, length(prob.u0), alg.order)
     S.y[1] = prob.u0
+    tableau = constructMIRK(S)
     # Upper-level iteration
     loss = function (z)
         z = nest_vector(z, S.M, S.N)
         copy!(S.y, z)
-        Φ!(S)
+        Φ!(S, tableau)
         flatten_vector(S.residual)
     end
     opt = alg.nlsolve(loss, flatten_vector(S.y))


### PR DESCRIPTION
MIRK currently has huge amount of allocations and very slow. [Here](https://github.com/YingboMa/MIRK-profile) is the profile plots and benchmark results of the following problem.

```
using BoundaryValueDiffEq
function fun!(x, u, du)
    du[1] = u[2]
    du[2] = -200*sin(u[1])
end

function boundary!(residual, u)
    residual[1] = u[1][1]
    residual[2] = u[end][1]+u[end÷2][1]+3+u[end÷2][2]
end

tspan = (0.,1.)
u0 = [0.,-2.]
dt = .02
bvp = BVProblem(fun!, boundary!, u0, tspan)
@profile sol = solve(bvp, MIRK(4), dt=dt)
```