### PR TITLE
Update for BandedMatrices.jl v0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ DiffEqBase
 Reexport
 NLsolve 0.14.0
 DiffEqDiffTools 0.2.0
-BandedMatrices
+BandedMatrices 0.4

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -14,7 +14,7 @@ function ConstructJacobian(f!::BVPJacobianWrapper, S::BVPSystem, y)
         f!(F,x)
     end
     j!(J, x::Array)  = (F = jac_cache.fx; fj!(F, J, x))
-    J0 = bzeros(eltype(S.y[1]), S.M*S.N, S.M*S.N, S.M-1, S.M-1)
+    J0 = BandedMatrix(Zeros{eltype(S.y[1])}(S.M*S.N, S.M*S.N), (S.M-1, S.M-1))
     NLsolve.OnceDifferentiable(f!.loss, j!, fj!, jac_cache.x1, jac_cache.fx, sparse(J0))
 end
 


### PR DESCRIPTION
`bzeros(T, n, m, l, u)` has been removed in favour of `BandedMatrix(Zeros{T}(n,m), (l,u))`